### PR TITLE
Update sqlite3 to version 4.0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "pg": "^4.5.5",
     "pkginfo": "~0.3.0",
     "semver": "~4.3.3",
-    "sqlite3": "^3.1.4"
+    "sqlite3": "4.0.8"
   },
   "devDependencies": {
     "code": "^1.3.0",


### PR DESCRIPTION
This PR updates the version of `sqlite3` to address vulnerabilities and needed dependency upgrades.